### PR TITLE
Add full type annotations for mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.mypy]
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+ignore_missing_imports = true
+no_implicit_optional = true
+no_implicit_reexport = true
+show_column_numbers = true
+show_error_codes = true
+show_traceback = true
+strict = true
+strict_equality = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_configs = true
+warn_unused_ignores = true


### PR DESCRIPTION
In the vod for your stream, you mentioned potentially checking with mypy.
This pull request does exactly that, adding complete type annotations to allow for type checking with mypy as well as the necessary configuration file for mypy.

I have made two minor functional changes that are noteworthy:
1. Removing unused imports from typing module
2. Decoding shell command bytes as utf-8 in `load_snapshots` instead so return type of `list[Snapshot]` is still usable and we don't need to make a separate copy of Snapshot typed dictionary.

With mypy installed, program will be type checkable by running
```
mypy rere.py
```
in project root directory without any errors.